### PR TITLE
Fix push handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,9 @@ RUN sed -i -r \
     -e 's/unqualified-search-registries .+/unqualified-search-registries = ["docker.io"]/' \
     /etc/containers/registries.conf
 
+# add git-credential helper
+COPY ./helpers/git-credential-env /usr/local/bin/git-credential-env
+RUN git config --system credential.helper env
+
 ADD . /repo2podman
 RUN pip install /repo2podman

--- a/helpers/git-credential-env
+++ b/helpers/git-credential-env
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo -e "$GIT_CREDENTIAL_ENV"

--- a/repo2podman/podman.py
+++ b/repo2podman/podman.py
@@ -10,6 +10,8 @@ from tempfile import TemporaryDirectory
 from threading import Thread
 from traitlets import Unicode
 
+from docker_image.reference import Reference
+
 from repo2docker.engine import (
     Container,
     ContainerEngine,
@@ -295,7 +297,7 @@ class PodmanEngine(ContainerEngine):
         log_debug(lines)
 
     default_transport = Unicode(
-        "docker://docker.io/",
+        "docker://",
         help="""
         Default transport image protocol if not specified in the image tag
         """,
@@ -436,7 +438,9 @@ class PodmanEngine(ContainerEngine):
         if re.match(r"\w+://", image_spec):
             destination = image_spec
         else:
-            destination = self.default_transport + image_spec
+            ref = Reference.parse_normalized_named(image_spec)
+            destination = self.default_transport + ref.string()
+
         args = ["push", image_spec, destination]
 
         def iter_out():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="repo2podman",
-    install_requires=["jupyter-repo2docker>=2021.08.0"],
+    install_requires=["jupyter-repo2docker>=2021.08.0", "docker-image-py"],
     python_requires=">=3.6",
     author="Simon Li",
     url="https://github.com/manics/repo2podman",


### PR DESCRIPTION
This merge request does mainly two things:

- refactor the image name handling
- add missing git credential helper script

The former allows to run the tool with non `docker.io` registries.
The latter allows to clone private repositories as the repo2docker image does.