### PR TITLE
Use different format arg when using `docker`.

### DIFF
--- a/repo2podman/podman.py
+++ b/repo2podman/podman.py
@@ -256,10 +256,7 @@ class PodmanContainer(Container):
     def __init__(self, cid, podman_executable="podman"):
         self.id = cid
         self._podman_executable = podman_executable
-        if podman_executable in ["docker"]:
-            self.format_arg = "{{json .}}"
-        else:
-            self.format_arg = "json"
+        self.format_arg = "{{json .}}"
         self.reload()
 
     def reload(self):
@@ -378,11 +375,7 @@ class PodmanEngine(ContainerEngine):
     def __init__(self, *, parent):
         super().__init__(parent=parent)
 
-        if self.podman_executable in ["docker"]:
-            self.format_arg = "{{json .}}"
-        else:
-            self.format_arg = "json"
-
+        self.format_arg = "{{json .}}"
         lines = exec_podman(["info"], capture="stdout", exe=self.podman_executable)
         log_debug(lines)
 

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -66,7 +66,7 @@ def test_run():
     c.remove()
     with pytest.raises(PodmanCommandError) as exc:
         c.reload()
-    assert "".join(exc.value.output).strip() == "[]"
+    assert "".join(exc.value.output).strip() == ""
 
 
 def test_run_autoremove():
@@ -77,7 +77,7 @@ def test_run_autoremove():
     sleep(3)
     with pytest.raises(PodmanCommandError) as exc:
         c.reload()
-    assert "".join(exc.value.output).strip() == "[]"
+    assert "".join(exc.value.output).strip() == ""
 
 
 def test_run_detach_wait():
@@ -93,7 +93,7 @@ def test_run_detach_wait():
     c.remove()
     with pytest.raises(PodmanCommandError) as exc:
         c.reload()
-    assert "".join(exc.value.output).strip() == "[]"
+    assert "".join(exc.value.output).strip() == ""
 
 
 def test_run_detach_nostream():
@@ -146,8 +146,8 @@ def test_custom_executable(tmp_path):
     exe = tmp_path.joinpath("custom_exe.sh")
     with exe.open("w") as f:
         f.write("#!/bin/sh\n")
-        f.write(f"echo $@ >> {log}\n")
-        f.write("exec podman $@\n")
+        f.write(f'echo "$@" >> {log}\n')
+        f.write('exec podman "$@"\n')
     exe.chmod(0o755)
 
     client = PodmanEngine(parent=None)
@@ -168,7 +168,7 @@ def test_custom_executable(tmp_path):
         lines = f.read().splitlines()
     assert lines == [
         f"run --detach --log-level=debug {BUSYBOX} id -un",
-        f"inspect --type container --format json {cid}",
+        f"inspect --type container --format {{{{json .}}}} {cid}",
         f"logs {cid}",
         f"rm {cid}",
     ]

--- a/tests/unit/test_podman.py
+++ b/tests/unit/test_podman.py
@@ -66,7 +66,8 @@ def test_run():
     c.remove()
     with pytest.raises(PodmanCommandError) as exc:
         c.reload()
-    assert "".join(exc.value.output).strip() == ""
+    # Podman 3 returns "[]" instead of ""
+    assert "".join(exc.value.output).strip() in ("[]", "")
 
 
 def test_run_autoremove():
@@ -77,7 +78,8 @@ def test_run_autoremove():
     sleep(3)
     with pytest.raises(PodmanCommandError) as exc:
         c.reload()
-    assert "".join(exc.value.output).strip() == ""
+    # Podman 3 returns "[]" instead of ""
+    assert "".join(exc.value.output).strip() in ("[]", "")
 
 
 def test_run_detach_wait():
@@ -93,7 +95,8 @@ def test_run_detach_wait():
     c.remove()
     with pytest.raises(PodmanCommandError) as exc:
         c.reload()
-    assert "".join(exc.value.output).strip() == ""
+    # Podman 3 returns "[]" instead of ""
+    assert "".join(exc.value.output).strip() in ("[]", "")
 
 
 def test_run_detach_nostream():


### PR DESCRIPTION
Fixes #85.