### PR TITLE
Test docker and nerdctl, upgrade to pytest 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,19 +6,21 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       # Do not cancel all jobs if one fails
       fail-fast: false
       matrix:
         python_version: ["3.9"]
+        container_engine:
+          - podman
         repo_type:
           # Only test a subset of the repo2docker tests since we're testing podman,
           # not the full repo2docker functionality
@@ -33,6 +35,19 @@ jobs:
           # - r
           - unit
           - venv/default
+        include:
+          - python_version: "3.11"
+            container_engine: docker
+            repo_type: base
+          - python_version: "3.11"
+            container_engine: docker
+            repo_type: venv/default
+          - python_version: "3.11"
+            container_engine: nerdctl
+            repo_type: base
+          - python_version: "3.11"
+            container_engine: nerdctl
+            repo_type: venv/default
 
     steps:
       - name: Checkout repo
@@ -44,6 +59,15 @@ jobs:
           python-version: ${{ matrix.python_version }}
           cache: pip
           cache-dependency-path: dev-requirements.txt
+
+      - name: Install nerdctl
+        if: matrix.container_engine == 'nerdctl'
+        run: |
+          NERDCTL_VERSION=1.7.4
+          sudo systemctl disable --now docker
+          curl -sfL https://github.com/containerd/nerdctl/releases/download/v$NERDCTL_VERSION/nerdctl-full-$NERDCTL_VERSION-linux-amd64.tar.gz | sudo tar -zxvf - -C /usr/local
+          containerd-rootless-setuptool.sh install
+          containerd-rootless-setuptool.sh install-buildkit
 
       - name: Install
         run: |
@@ -67,7 +91,11 @@ jobs:
           done
 
       - name: Run tests
-        run: pytest -v tests/${{ matrix.repo_type }}
+        run: |
+          export CONTAINER_ENGINE=${{ matrix.container_engine }}
+          which $CONTAINER_ENGINE
+          $CONTAINER_ENGINE version
+          pytest -v tests/${{ matrix.repo_type }}
 
   # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   publish-pypi:
@@ -76,7 +104,7 @@ jobs:
       # Only publish if other jobs passed
       - lint
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -147,7 +175,7 @@ jobs:
   status_all:
     name: Status matrix Test
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
       - test

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 build==1.0.3
 jupyter-repo2docker==2023.6.0
-pytest==7.4.4
+pytest==8.0.2
 pre-commit==3.6.2

--- a/repo2podman/podman.py
+++ b/repo2podman/podman.py
@@ -327,7 +327,7 @@ class PodmanContainer(Container):
 
     def stop(self, *, timeout=10):
         lines = exec_podman(
-            ["stop", "--timeout", str(timeout), self.id],
+            ["stop", "--time", str(timeout), self.id],
             capture="stdout",
             exe=self._podman_executable,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,9 @@ import yaml
 from repo2docker.__main__ import make_r2d
 
 
+CONTAINER_ENGINE = os.getenv("CONTAINER_ENGINE")
+
+
 def pytest_collect_file(parent, path):
     if path.basename == "verify":
         return LocalRepo.from_parent(parent, fspath=path)
@@ -99,9 +102,10 @@ class LocalRepo(pytest.File):
         args = [
             "--appendix",
             'RUN echo "appendix" > /tmp/appendix',
-            "--engine",
-            "podman",
+            "--engine=podman",
         ]
+        if CONTAINER_ENGINE:
+            args.append(f"--PodmanEngine.podman_executable={CONTAINER_ENGINE}")
         # If there's an extra-args.yaml file in a test dir, assume it contains
         # a yaml list with extra arguments to be passed to repo2docker
         extra_args_path = os.path.join(self.fspath.dirname, "extra-args.yaml")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,8 @@ class LocalRepo(pytest.File):
             extra_args = yaml.safe_load(extra_args_path.read_text())
             args += extra_args
 
+        # Avoid overly long image names
+        args.append("--image-name=" + "-".join(self.path.parent.parts[-3:]))
         args.append(str(self.path.parent))
 
         yield Repo2DockerTest.from_parent(self, name="build", args=args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,11 +22,11 @@ from repo2docker.__main__ import make_r2d
 CONTAINER_ENGINE = os.getenv("CONTAINER_ENGINE")
 
 
-def pytest_collect_file(parent, path):
-    if path.basename == "verify":
-        return LocalRepo.from_parent(parent, fspath=path)
-    # elif path.basename.endswith(".repos.yaml"):
-    #     return RemoteRepoList(path, parent)
+def pytest_collect_file(parent, file_path):
+    if file_path.name == "verify":
+        return LocalRepo.from_parent(parent, path=file_path)
+    # elif file_path.name.endswith(".repos.yaml"):
+    #     return RemoteRepoList.from_parent(parent, path=file_path)
 
 
 def make_test_func(args):
@@ -82,7 +82,7 @@ class Repo2DockerTest(pytest.Function):
         super().__init__(name, parent, callobj=f)
 
     def reportinfo(self):
-        return self.parent.fspath, None, ""
+        return self.parent.path, None, ""
 
     def repr_failure(self, excinfo):
         err = excinfo.value
@@ -108,15 +108,14 @@ class LocalRepo(pytest.File):
             args.append(f"--PodmanEngine.podman_executable={CONTAINER_ENGINE}")
         # If there's an extra-args.yaml file in a test dir, assume it contains
         # a yaml list with extra arguments to be passed to repo2docker
-        extra_args_path = os.path.join(self.fspath.dirname, "extra-args.yaml")
-        if os.path.exists(extra_args_path):
-            with open(extra_args_path) as f:
-                extra_args = yaml.safe_load(f)
+        extra_args_path = self.path.parent / "test-extra-args.yaml"
+        if extra_args_path.exists():
+            extra_args = yaml.safe_load(extra_args_path.read_text())
             args += extra_args
 
-        args.append(self.fspath.dirname)
+        args.append(str(self.path.parent))
 
         yield Repo2DockerTest.from_parent(self, name="build", args=args)
         yield Repo2DockerTest.from_parent(
-            self, name=self.fspath.basename, args=args + ["./verify"]
+            self, name=self.path.name, args=args + ["./verify"]
         )


### PR DESCRIPTION
- Add basic tests with Docker and Nerdctl
- Fixes removed functionality in Pytest 8 https://github.com/jupyterhub/repo2docker/pull/1330
- Overrides image-name as overly long names cause problems with nerdctl